### PR TITLE
fix: remove appcontext which is removed in flask

### DIFF
--- a/flask_cas/__init__.py
+++ b/flask_cas/__init__.py
@@ -5,14 +5,6 @@ flask_cas.__init__
 import flask
 from flask import current_app
 
-# Find the stack on which we want to store the database connection.
-# Starting with Flask 0.9, the _app_ctx_stack is the correct one,
-# before that we need to use the _request_ctx_stack.
-try:
-    from flask import _app_ctx_stack as stack
-except ImportError:
-    from flask import _request_ctx_stack as stack
-
 from . import routing
 
 from functools import wraps
@@ -65,7 +57,7 @@ class CAS(object):
             app.teardown_request(self.teardown)
 
     def teardown(self, exception):
-        ctx = stack.top
+        pass
     
     @property
     def app(self):


### PR DESCRIPTION
I had the following bug:
```
File "/tmp/wex/lib/python3.11/site-packages/flask_cas/__init__.py", line 14, in <module>
 from flask import _request_ctx_stack as stack
ImportError: cannot import name '_request_ctx_stack' from 'flask' (/tmp/wex/lib/python3.11/site-packages/flask/__init__.py)
```

After some investigations: `_app_ctx_stack` and `_request_ctx_stack` were removed in flask. See [this PR on flask](https://github.com/pallets/flask/pull/4682). 

In this extension, contexts are not used, these line are here as a copy of [the flask extension dev doc](https://flask-ptbr.readthedocs.io/en/latest/extensiondev.html). These line didn't have side effect, to the removal of this line is sufficiant to solve the bug.